### PR TITLE
Enable highlight test.

### DIFF
--- a/haskell-language-server.cabal
+++ b/haskell-language-server.cabal
@@ -197,6 +197,7 @@ common hls-test-utils
     , hslogger
     , hspec
     , hspec-core
+    , lens
     , lsp-test              >=0.11.0.6
     , stm
     , tasty-hunit

--- a/test/functional/Highlight.hs
+++ b/test/functional/Highlight.hs
@@ -1,20 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Highlight (tests) where
 
-import Control.Applicative.Combinators
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hls.Util
 import Test.Tasty
-import Test.Tasty.ExpectedFailure (ignoreTestBecause)
 import Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "highlight" [
-    ignoreTestBecause "Broken" $ testCase "works" $ runSession hlsCommand fullCaps "test/testdata" $ do
+    testCase "works" $ runSession hlsCommand fullCaps "test/testdata" $ do
         doc <- openDoc "Highlight.hs" "haskell"
-        _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
+        _ <- waitForDiagnosticsFrom doc
         highlights <- getHighlights doc (Position 2 2)
         liftIO $ do
             let hls =

--- a/test/testdata/hie.yaml
+++ b/test/testdata/hie.yaml
@@ -4,6 +4,7 @@ cradle:
       - "CodeActionImport"
       - "CodeActionOnly"
       - "CodeActionRename"
+      - "Highlight"
       - "TopLevelSignature"
       - "TypedHoles"
       - "TypedHoles2"


### PR DESCRIPTION
getHighlights already skips extraneous messages, so there is no need to skip any
of them manually. Especially when we end up skipping the wrong ones.