### PR TITLE
Delete unused utilities for controlling logging.

### DIFF
--- a/test/functional/FunctionalBadProject.hs
+++ b/test/functional/FunctionalBadProject.hs
@@ -24,7 +24,6 @@ tests = testGroup "behaviour on malformed projects" [
 
     -- testCase "deals with cabal file with unsatisfiable dependency" $
     --     runSession hlsCommandExamplePlugin codeActionSupportCaps "test/testdata/badProjects/cabal" $ do
-    --     -- runSessionWithConfig logConfig hlsCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
     --         _doc <- openDoc "Foo.hs" "haskell"
 
     --         diags@(d:_) <- waitForDiagnosticsSource "bios"

--- a/test/functional/FunctionalLiquid.hs
+++ b/test/functional/FunctionalLiquid.hs
@@ -52,7 +52,6 @@ tests = testGroup "liquid haskell diagnostics" [
 
     , ignoreTestBecause "Broken" $ testCase "runs diagnostics on save, with liquid haskell" $
         runSession hlsCommand codeActionSupportCaps "test/testdata" $ do
-        -- runSessionWithConfig logConfig hlsCommand codeActionSupportCaps "test/testdata" $ do
             doc <- openDoc "liquid/Evens.hs" "haskell"
 
             diags@(reduceDiag:_) <- waitForDiagnostics

--- a/test/utils/Test/Hls/Util.hs
+++ b/test/utils/Test/Hls/Util.hs
@@ -20,14 +20,11 @@ module Test.Hls.Util
     , inspectCommand
     , inspectDiagnostic
     , knownBrokenForGhcVersions
-    , logConfig
     , logFilePath
-    , noLogConfig
     , setupBuildToolFiles
     , waitForDiagnosticsFrom
     , waitForDiagnosticsFromSource
     , waitForDiagnosticsFromSourceWithTimeout
-    , withFileLogging
     , withCurrentDirectoryInTmp
   )
 where
@@ -63,34 +60,12 @@ import           Test.Tasty.HUnit (assertFailure)
 import           Text.Blaze.Renderer.String (renderMarkup)
 import           Text.Blaze.Internal hiding (null)
 
-
-noLogConfig :: Test.SessionConfig
-noLogConfig = Test.defaultConfig { Test.logMessages = False }
-
-logConfig :: Test.SessionConfig
-logConfig = Test.defaultConfig { Test.logMessages = True }
-
 codeActionSupportCaps :: C.ClientCapabilities
 codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }
   where
     textDocumentCaps = def { C._codeAction = Just codeActionCaps }
     codeActionCaps = C.CodeActionClientCapabilities (Just True) (Just literalSupport)
     literalSupport = C.CodeActionLiteralSupport def
-
-withFileLogging :: FilePath -> IO a -> IO a
-withFileLogging logFile f = do
-  let logDir = "./test-logs"
-      logPath = logDir </> logFile
-
-  dirExists <- doesDirectoryExist logDir
-  unless dirExists $ createDirectory logDir
-
-  exists <- doesFileExist logPath
-  when exists $ removeFile logPath
-
-  setupLogger (Just logPath) ["hie"] L.DEBUG
-
-  f
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
Delete withFileLogging, logConfig, and noLogConfig.

Logging is turned on by hlsCommand. Should we ever want to disable it for a
certain test, we would create a new version of hlsCommand, say, hlsCommandNoLog.